### PR TITLE
Use Volley native listeners instead our implementation

### DIFF
--- a/src/com/wordpress/rest/Oauth.java
+++ b/src/com/wordpress/rest/Oauth.java
@@ -1,19 +1,16 @@
 package com.wordpress.rest;
 
-import android.util.Log;
-
-import com.android.volley.Response;
-import com.android.volley.ParseError;
-import com.android.volley.toolbox.HttpHeaderParser;
-import com.android.volley.NetworkResponse;
-
-import org.json.JSONObject;
-import org.json.JSONException;
-
 import java.io.UnsupportedEncodingException;
-
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.android.volley.NetworkResponse;
+import com.android.volley.ParseError;
+import com.android.volley.Response;
+import com.android.volley.toolbox.HttpHeaderParser;
 
 public class Oauth {
 

--- a/src/com/wordpress/rest/RestClient.java
+++ b/src/com/wordpress/rest/RestClient.java
@@ -1,18 +1,15 @@
 package com.wordpress.rest;
 
-import android.util.Log;
-import android.content.Context;
-
-import com.android.volley.RequestQueue;
-import com.android.volley.toolbox.JsonRequest;
-import com.android.volley.Response.Listener;
-import com.android.volley.Response.ErrorListener;
-import com.android.volley.toolbox.Volley;
-import com.android.volley.Request.Method;
-
-import java.util.Map;
-import java.net.URLEncoder;
 import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Map;
+
+import org.json.JSONObject;
+
+import com.android.volley.Request.Method;
+import com.android.volley.RequestQueue;
+import com.android.volley.Response.ErrorListener;
+import com.android.volley.Response.Listener;
 
 public class RestClient {
 
@@ -33,18 +30,16 @@ public class RestClient {
         mAccessToken = token;
     }
 
-    public RestRequest get(String path, RestRequest.Listener listener,
-                           RestRequest.ErrorListener errorListener){
+    public RestRequest get(String path, Listener<JSONObject> listener, ErrorListener errorListener){
         return makeRequest(Method.GET, getAbsoluteURL(path), null, listener, errorListener);
     }
 
-    public RestRequest post(String path, Map<String,String> body, RestRequest.Listener listener,
-                            RestRequest.ErrorListener errorListener){
+    public RestRequest post(String path, Map<String,String> body, Listener<JSONObject> listener, ErrorListener errorListener){
         return makeRequest(Method.POST, getAbsoluteURL(path), body, listener, errorListener);
     }
     
     public RestRequest makeRequest(int method, String url, Map<String, String> params,
-                                   RestRequest.Listener listener, RestRequest.ErrorListener errorListener ){
+                                   Listener<JSONObject> listener, ErrorListener errorListener ){
         RestRequest request = new RestRequest(method, url, params, listener, errorListener);
         request.setUserAgent(mUserAgent);
         request.setAccessToken(mAccessToken);

--- a/src/com/wordpress/rest/RestRequest.java
+++ b/src/com/wordpress/rest/RestRequest.java
@@ -20,14 +20,14 @@ public class RestRequest extends Request<JSONObject> {
     public static final String REST_AUTHORIZATION_HEADER="Authorization";
     public static final String REST_AUTHORIZATION_FORMAT="Bearer %s";
 
-    public interface Listener extends Response.Listener<JSONObject> {}
-    public interface ErrorListener extends Response.ErrorListener {}
+    public interface Listener extends Response.Listener<JSONObject> {} //This is just a shortcut for Response.Listener<JSONObject> 
+    public interface ErrorListener extends Response.ErrorListener {} //This is just a shortcut for Response.ErrorListener
     
-    private final Listener mListener;
+    private final com.android.volley.Response.Listener<JSONObject> mListener;
     private final Map<String,String> mParams;
     private final Map<String,String> mHeaders = new HashMap<String,String>(2);
-    public RestRequest(int method, String url, Map<String, String> params, Listener listener,
-                       ErrorListener errorListener){
+    public RestRequest(int method, String url, Map<String, String> params, com.android.volley.Response.Listener<JSONObject> listener,
+    		com.android.volley.Response.ErrorListener errorListener){
         super(method, url, errorListener);
         mParams = params;
         mListener = listener;


### PR DESCRIPTION
We should use Volley native listeners instead of our implementation in method declaration. Our Listeners are just a shortcut to the native version.
<code>
public interface Listener extends Response.Listener&lt;JSONObject&gt; {}
public interface ErrorListener extends Response.ErrorListener {}
</code>

Using the more generic type, that is built-in in Volley, will give us the ability of making synchronous calls, and other nice things, without modify the REST Client internals.
