### PR TITLE
Upgrade to Rest Endpoints v1.0.3

### DIFF
--- a/WordPressComRest/build.gradle
+++ b/WordPressComRest/build.gradle
@@ -21,7 +21,7 @@ android {
     buildToolsVersion "21.1.2"
 
     defaultConfig {
-        versionName "1.0.2"
+        versionName "1.0.3"
         minSdkVersion 14
         targetSdkVersion 20
     }

--- a/WordPressComRest/src/main/java/com/wordpress/rest/RestClient.java
+++ b/WordPressComRest/src/main/java/com/wordpress/rest/RestClient.java
@@ -13,12 +13,13 @@ import java.util.Map;
 
 public class RestClient {
     public static final String TAG = "WordPressREST";
-    public static enum REST_CLIENT_VERSIONS {V1, V1_1, V1_2}
+    public static enum REST_CLIENT_VERSIONS {V1, V1_1, V1_2, V1_3}
     public static final String PARAMS_ENCODING = "UTF-8";
 
     protected static final String REST_API_ENDPOINT_URL_V1 = "https://public-api.wordpress.com/rest/v1/";
     protected static final String REST_API_ENDPOINT_URL_V1_1 = "https://public-api.wordpress.com/rest/v1.1/";
     protected static final String REST_API_ENDPOINT_URL_V1_2 = "https://public-api.wordpress.com/rest/v1.2/";
+    protected static final String REST_API_ENDPOINT_URL_V1_3 = "https://public-api.wordpress.com/rest/v1.3/";
 
     private RequestQueue mQueue;
     private String mAccessToken;
@@ -33,7 +34,9 @@ public class RestClient {
     public RestClient(RequestQueue queue, REST_CLIENT_VERSIONS version) {
         mQueue = queue;
 
-        if (version == REST_CLIENT_VERSIONS.V1_2) {
+        if (version == REST_CLIENT_VERSIONS.V1_3) {
+            mRestApiEndpointURL = REST_API_ENDPOINT_URL_V1_3;
+        } else if (version == REST_CLIENT_VERSIONS.V1_2) {
             mRestApiEndpointURL = REST_API_ENDPOINT_URL_V1_2;
         } else if (version == REST_CLIENT_VERSIONS.V1_1) {
             mRestApiEndpointURL = REST_API_ENDPOINT_URL_V1_1;

--- a/WordPressComRest/src/main/java/com/wordpress/rest/RestRequest.java
+++ b/WordPressComRest/src/main/java/com/wordpress/rest/RestRequest.java
@@ -7,6 +7,7 @@ import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.HttpHeaderParser;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONException;
 
@@ -111,7 +112,16 @@ public class RestRequest extends Request<JSONObject> {
     protected Response<JSONObject> parseNetworkResponse(NetworkResponse response) {
         try {
             String jsonString = new String(response.data, HttpHeaderParser.parseCharset(response.headers));
-            return Response.success(new JSONObject(jsonString), HttpHeaderParser.parseCacheHeaders(response));
+
+            try {
+                return Response.success(new JSONObject(jsonString), HttpHeaderParser.parseCacheHeaders(response));
+            } catch (JSONException parseErr) {
+                // Try to parse the response document as Array
+                JSONArray responseArray = new JSONArray(jsonString);
+                JSONObject wrapper = new JSONObject();
+                wrapper.put("originalResponse", responseArray);
+                return Response.success(wrapper, HttpHeaderParser.parseCacheHeaders(response));
+            }
         } catch (UnsupportedEncodingException e) {
             return Response.error(new ParseError(e));
         } catch (JSONException je) {


### PR DESCRIPTION
Add suport for rest endpoints version 1.0.3
Also bump version number.

Once this PR is merged a new version should be published on Sonatype.