### PR TITLE
Makes handling boolean return values possible

### DIFF
--- a/WordPressComRest/build.gradle
+++ b/WordPressComRest/build.gradle
@@ -20,7 +20,7 @@ android {
     buildToolsVersion "23.0.2"
 
     defaultConfig {
-        versionName "1.0.3"
+        versionName "1.0.4"
         minSdkVersion 14
         targetSdkVersion 23
     }
@@ -103,6 +103,12 @@ afterEvaluate {
                             id 'maxme'
                             name 'Maxime Biais'
                             email 'maxime@automattic.com'
+                        }
+
+                        developer {
+                            id 'kwonye'
+                            name 'Will Kwon'
+                            email 'will@automattic.com'
                         }
                     }
                 }

--- a/WordPressComRest/build.gradle
+++ b/WordPressComRest/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
     }
 }
 
@@ -12,23 +12,22 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 android {
-
-    compileSdkVersion 19
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         versionName "1.0.3"
         minSdkVersion 14
-        targetSdkVersion 20
+        targetSdkVersion 23
     }
 }
 
 dependencies {
-    compile 'com.mcxiaoke.volley:library:1.0.16'
+    compile 'com.android.volley:volley:1.0.0'
 }
 
 version android.defaultConfig.versionName

--- a/WordPressComRest/build.gradle
+++ b/WordPressComRest/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.volley:volley:1.0.0'
+    compile 'com.mcxiaoke.volley:library:1.0.16'
 }
 
 version android.defaultConfig.versionName

--- a/WordPressComRest/src/main/java/com/wordpress/rest/Oauth.java
+++ b/WordPressComRest/src/main/java/com/wordpress/rest/Oauth.java
@@ -65,11 +65,13 @@ public class Oauth {
         return String.format(AUTHORIZED_ENDPOINT_FORMAT, AUTHORIZE_ENDPOINT, getAppID(), getAppRedirectURI());
     }
 
+    @SuppressWarnings("unused")
     public Request makeRequest(String username, String password, String twoStepCode, boolean shouldSendTwoStepSMS, Listener listener, ErrorListener errorListener) {
         return new PasswordRequest(getAppID(), getAppSecret(), getAppRedirectURI(), username, password, twoStepCode, shouldSendTwoStepSMS, listener,
                 errorListener);
     }
 
+    @SuppressWarnings("unused")
     public Request makeRequest(String code, Listener listener, ErrorListener errorListener) {
         return new BearerRequest(getAppID(), getAppSecret(), getAppRedirectURI(), code, listener, errorListener);
     }

--- a/WordPressComRest/src/main/java/com/wordpress/rest/RestRequest.java
+++ b/WordPressComRest/src/main/java/com/wordpress/rest/RestRequest.java
@@ -157,7 +157,7 @@ public class RestRequest extends Request<JSONObject> {
             jsonObject.put(ORIGINAL_RESPONSE, false);
             return jsonObject;
         } else {
-            throw new JSONException("Not a boolean");
+            throw new JSONException("Not a valid JSON response: " + jsonString);
         }
     }
 }


### PR DESCRIPTION
There are a instances when "true" is returned by the API. (example: `https://public-api.wordpress.com/is-available/email?q=[email]`)

Technically this is valid JSON, but we do not correctly handle it. Now, we create a JSONObject that the app can consume.

Needs review: @daniloercoli 